### PR TITLE
Added a hook to shutdown the underlying http client library

### DIFF
--- a/src/main/scala/wabisabi/Client.scala
+++ b/src/main/scala/wabisabi/Client.scala
@@ -306,3 +306,17 @@ class Client(esURL: String) extends Logging {
     Http(req.setHeader("Content-type", "application/json; charset=utf-8"))
   }
 }
+
+object Client {
+  /**
+   * Disconnects any remaining connections. Both idle and active. If you are accessing
+   * Elasticsearch through a proxy that keeps connections alive this is useful.
+   *
+   * If your application uses the dispatch library for other purposes, those connections
+   * will also terminate.
+   */
+  def shutdown() {
+    Http.shutdown()
+  }
+
+}


### PR DESCRIPTION
It doesn't really do much beyond documenting that sometimes it will be necessary to explicitly shutdown connections, but I like to find such stuff in the code.
