### PR TITLE
add bulk method that accepts data as byte array

### DIFF
--- a/src/main/scala/wabisabi/Client.scala
+++ b/src/main/scala/wabisabi/Client.scala
@@ -21,7 +21,18 @@ class Client(esURL: String) extends Logging {
    * @param data The operations to perform as described by the [[http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html ElasticSearch Bulk API]].
    */
   def bulk(index: Option[String] = None, `type`: Option[String] = None, data: String): Future[Response] = {
-    val freq = (url(esURL) / index.getOrElse("") / `type`.getOrElse("") / "_bulk").setBody(data.getBytes(StandardCharsets.UTF_8))
+    bulk(index, `type`, data.getBytes(StandardCharsets.UTF_8))
+  }
+
+  /**
+   * Use the bulk API to perform many index/delete operations in a single call.
+   *
+   * @param index The optional index name.
+   * @param type The optional type.
+   * @param data The operations to perform as described by the [[http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html ElasticSearch Bulk API]].
+   */
+  def bulk(index: Option[String] = None, `type`: Option[String] = None, data: Array[Byte]): Future[Response] = {
+    val freq = (url(esURL) / index.getOrElse("") / `type`.getOrElse("") / "_bulk").setBody(data))
     doRequest(freq.POST)
   }
 


### PR DESCRIPTION
it would be great to have a bulk method that accepts data as byte array, this is necessary because data can be large and i want to send it gzip compressed (ES: http.compression: true)
