### PR TITLE
Remove URL parsing, as I'm not sure what it adds.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,6 @@ libraryDependencies += "org.specs2" %% "specs2" % "2.3.11" % "test"
 
 libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.5" % "test"
 
-libraryDependencies += "com.netaporter" %% "scala-uri" % "0.4.3"
-
 publishTo := Some(Resolver.file("file",  new File( "/Users/gphat/src/mvn-repo/releases" )) )
 
 

--- a/src/main/scala/wabisabi/Client.scala
+++ b/src/main/scala/wabisabi/Client.scala
@@ -8,9 +8,6 @@ import java.net.URL
 import scala.concurrent.Promise
 import java.nio.charset.StandardCharsets
 
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
-
 class Client(esURL: String) extends Logging {
 
   // XXX multiget, update, multisearch, percolate, more like this,
@@ -342,39 +339,6 @@ class Client(esURL: String) extends Logging {
     val breq = req.toRequest
     debug("%s: %s".format(breq.getMethod, breq.getUrl))
     Http(req.setHeader("Content-type", "application/json; charset=utf-8"))
-  }
-
-
-  private def url(es_url: String) = {
-
-    val uri: Uri = es_url
-
-    val protocol = uri.protocol.getOrElse("http")
-    val port = uri.port.getOrElse(protocol match {
-      case "http" => 80
-      case "https" => 443
-    })
-
-    val req = if (uri.user.isDefined && uri.password.isDefined) {
-
-      dispatch.url(protocol+"://"+uri.host.get+":"+port).as_!(uri.user.get, uri.password.get)
-    }
-
-    else {
-      dispatch.url(protocol+"://"+uri.host.get+":"+port)
-
-    }
-
-    protocol match {
-      case "http" => req
-      case "https" => req.secure
-      case _ => {
-        logger.error("Unknown protocol: %s".format(protocol))
-        dispatch.url("")
-      }
-    }
-
-
   }
 }
 

--- a/src/main/scala/wabisabi/Client.scala
+++ b/src/main/scala/wabisabi/Client.scala
@@ -8,7 +8,11 @@ import java.net.URL
 import scala.concurrent.Promise
 import java.nio.charset.StandardCharsets
 
-class Client(esURL: String) extends Logging {
+class Client(esURL: String, username: Option[String] = None, password: Option[String] = None) extends Logging {
+
+  if(username.isDefined && password.isEmpty) {
+    throw new IllegalArgumentException("Please provide a username and password together!")
+  }
 
   // XXX multiget, update, multisearch, percolate, more like this,
   //
@@ -339,6 +343,14 @@ class Client(esURL: String) extends Logging {
     val breq = req.toRequest
     debug("%s: %s".format(breq.getMethod, breq.getUrl))
     Http(req.setHeader("Content-type", "application/json; charset=utf-8"))
+  }
+
+  private def url(es_url: String) = {
+    username.map({ user =>
+      dispatch.url(es_url).as_!(user, password.get)
+    }).getOrElse({
+      dispatch.url(es_url)
+    })
   }
 }
 


### PR DESCRIPTION
First, let me apologize for merging this without looking at it closely. :(

Hey @jfelectron, I wonder if you could chime in here and help me with this?

You're #10 parses the URL and re-adds them do the dispatch URL. How is this better or different from using the username and password encoded into the URL itself? Perhaps I'm missing something about dispatch. :)

Also, this I'd like @blast-hardcheese's feedback too since this change (as it stands) would return us to the previous default behavior.

I'd like to get both the auth functionality and the previous behavior back.