### PR TITLE
Added support for search_type and scroll URI parameters to search.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,18 @@ asynchronous HTTP library. Therefore, all of the returned values are
 The returned object is a [Response](http://sonatype.github.io/async-http-client/apidocs/reference/com/ning/http/client/Response.html)
 from the async-http-client library. Normally you'll want to use `getResponseBody`
 to get the response but you can also check `getStatusCode` to verify something
-didn't go awry.
+didn't go awry. Since the returned response object is wrapped in a Future, you would need to `map` over it to get a
+Future of response code or body, e.g.:
+
+```
+val futureStatusCode: Future[Int] = client.verifyIndex("foo").map(_.getStatusCode)
+```
+
+Or,
+
+```
+val futureResponseBody: Future[String] = client.verifyIndex("foo").map(_.getResponseBody)
+```
 
 ## Dependencies
 
@@ -62,7 +73,7 @@ client.health
 client.createIndex(name = "foo")
 
 // Verify the index exists
-client.verifyIndex("foo").getStatusCode // Should be 200!
+client.verifyIndex("foo").map(_.getStatusCode) // Should be Future(200)
 
 // Get mapping
 client.getMapping(indices = Seq("foo"), types = Seq("bar"))
@@ -80,16 +91,16 @@ client.index(
 )
 
 // Fetch that document by it's id.
-client.get("foo", "foo", "foo").getResponseBody
+client.get("foo", "foo", "foo").map(_.getResponseBody)
 
 // Search for all documents.
-client.search(index = "foo", query = "{\"query\": { \"match_all\": {} }").getResponseBody
+client.search(index = "foo", query = "{\"query\": { \"match_all\": {} }").map(_.getResponseBody)
 
 // Search for all documents of a specific type!
-client.search(index = "foo", query = "{\"query\": { \"match_all\": {} }", `type`= "tweet").getResponseBody
+client.search(index = "foo", query = "{\"query\": { \"match_all\": {} }", `type`= "tweet").map(_.getResponseBody)
 
 // Validate a query.
-client.validate(index = "foo", query = "{\"query\": { \"match_all\": {} }").getStatusCode // Should be 200
+client.validate(index = "foo", query = "{\"query\": { \"match_all\": {} }").map(_.getStatusCode) // Should be Future(200)
 
 // Explain a query.
 client.explain(index = "foo", `type` = "foo", id = "foo2", query = "{\"query\": { \"term\": { \"foo\":\"bar\"} } }")
@@ -104,7 +115,7 @@ client.delete("foo", "foo", "foo")
 client.deleteByQuery(Seq("foo"), Seq.empty[String], "{ \"match_all\": {} }")
 
 // Count the matches to a query
-client.count(Seq("foo"), Seq("foo"), "{\"query\": { \"match_all\": {} }").getResponseBody
+client.count(Seq("foo"), Seq("foo"), "{\"query\": { \"match_all\": {} }").map(_.getResponseBody)
 
 // Delete the index
 client.deleteIndex("foo")

--- a/README.md
+++ b/README.md
@@ -99,12 +99,15 @@ client.search(index = "foo", query = "{\"query\": { \"match_all\": {} }").map(_.
 // Search for all documents of a specific type!
 client.search(index = "foo", query = "{\"query\": { \"match_all\": {} }", `type`= "tweet").map(_.getResponseBody)
 
-// Search for all documents with customised search URI parameters as per [this](http://www.elastic.co/guide/en/elasticsearch/reference/current/search-uri-request.html) reference document.
+// SearchUriParameters case class allows for customised search URI parameters, such as search_type to be passed in a search request as per [this](http://www.elastic.co/guide/en/elasticsearch/reference/current/search-uri-request.html) reference document.
+// The list of different search types, in addition to documentation on how each search type is executed by elasticsearch can be seen [here](http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-search-type.html).
+// For example, to search for all documents with `Count` search type:
 client.search(index = "foo", query = "{\"query\": { \"match_all\": {} }}",
-    uriParameters = SearchUriParameters(searchType = Some(Count))).getResponseBody // search_type set to Count
+    uriParameters = SearchUriParameters(searchType = Some(Count)))
 
+// Or, search for all documents with a `Scan` search type and a given scroll timeout (used for quick retrieval of all documents without sorting):
 client.search(index = "foo", query = "{\"query\": { \"match_all\": {} }}",
-    uriParameters = SearchUriParameters(scroll = Some("1m"), searchType = Some(Scan))) // Scanning all the documents with one minute scrolls
+    uriParameters = SearchUriParameters(scroll = Some("1m"), searchType = Some(Scan)))
 
 // Validate a query.
 client.validate(index = "foo", query = "{\"query\": { \"match_all\": {} }").map(_.getStatusCode) // Should be Future(200)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ client.search(index = "foo", query = "{\"query\": { \"match_all\": {} }").map(_.
 // Search for all documents of a specific type!
 client.search(index = "foo", query = "{\"query\": { \"match_all\": {} }", `type`= "tweet").map(_.getResponseBody)
 
+// Search for all documents with customised search URI parameters as per [this](http://www.elastic.co/guide/en/elasticsearch/reference/current/search-uri-request.html) reference document.
+client.search(index = "foo", query = "{\"query\": { \"match_all\": {} }}",
+    uriParameters = SearchUriParameters(searchType = Some(Count))).getResponseBody // search_type set to Count
+
+client.search(index = "foo", query = "{\"query\": { \"match_all\": {} }}",
+    uriParameters = SearchUriParameters(scroll = Some("1m"), searchType = Some(Scan))) // Scanning all the documents with one minute scrolls
+
 // Validate a query.
 client.validate(index = "foo", query = "{\"query\": { \"match_all\": {} }").map(_.getStatusCode) // Should be Future(200)
 

--- a/src/test/scala/ClientSpec.scala
+++ b/src/test/scala/ClientSpec.scala
@@ -189,6 +189,20 @@ class ClientSpec extends Specification with JsonMatchers {
       deleteIndex(client)("foo")
     }
 
+    "search with search_type and scroll parameters" in {
+      val client = new Client(s"http://localhost:${server.httpPort}")
+
+      index(client)(index = "foo", `type` = "bar", id = "bar1", data = Some("{\"abc\":\"def\"}"))
+
+      Await.result(client.search("foo", "{\"query\": { \"match_all\": {} } }", Some("bar"),
+        SearchUriParameters(scroll = Some("1m"))), testDuration).getResponseBody must contain("\"bar1\"")
+
+      Await.result(client.search("foo", "{\"query\": { \"match_all\": {} } }", Some("bar"),
+        SearchUriParameters(scroll = Some("1m"), searchType = Some(Scan))), testDuration).getResponseBody must contain("\"_scroll_id\"")
+
+      deleteIndex(client)("foo")
+    }
+
     "multi-search" in {
 
       val client = new Client(s"http://localhost:${server.httpPort}")


### PR DESCRIPTION
For additional type safety and expressiveness, I've used case classes to model URI parameters and search types. The SearchUriParameters case class can be extended further for more URI parameters in future as per this document:
http://www.elastic.co/guide/en/elasticsearch/reference/1.4/search-uri-request.html

@Maintainers, let me know if it's not inline with the original design principles of this library.