### PR TITLE
Add a source uri parameter to mget method for get the doc results which just include specific fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ val firstPageOfResults = // Extract results from the first scroll response.
 val nextScrollId = // Extract _scroll_id from the first scroll response.
 // Continue with subsequent scroll requests using the _scroll_id returned from previous requests until no more hits are returned.
 
+// Fetch all the documents by ids.
+// MGetUriParameters case class allows to specify the source fields in result documents.
+val mgetResponse = client.mget(index = "foo",`type` = Some("tweet"), query = "{\"ids\":[\"1\", \"2\"]}",
+    uriParameters = MGetUriParameters(sourceFields = Seq("name", "age")))
+
 // Validate a query.
 client.validate(index = "foo", query = "{\"query\": { \"match_all\": {} }").map(_.getStatusCode) // Should be Future(200)
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ val nextScrollId = // Extract _scroll_id from the first scroll response.
 // Continue with subsequent scroll requests using the _scroll_id returned from previous requests until no more hits are returned.
 
 // Fetch all the documents by ids.
-// MGetUriParameters case class allows to specify the source fields in result documents.
+// MGetUriParameters case class allows you to specify the source fields in result documents.
 val mgetResponse = client.mget(index = "foo",`type` = Some("tweet"), query = "{\"ids\":[\"1\", \"2\"]}",
     uriParameters = MGetUriParameters(sourceFields = Seq("name", "age")))
 

--- a/src/main/scala/wabisabi/Client.scala
+++ b/src/main/scala/wabisabi/Client.scala
@@ -172,10 +172,17 @@ class Client(esURL: String) extends Logging {
    * @param index The optional name of the index.
    * @param type The optional type of the document.
    * @param query The query to execute.
+   * @param uriParameters The query uri parameters.
    */
-  def mget(index: Option[String], `type`: Option[String], query: String): Future[Response] = {
+  def mget(index: Option[String], `type`: Option[String], query: String,
+    uriParameters: MGetUriParameters = MGetUriParameters.withDefaults): Future[Response] = {
     val req = (url(esURL) / index.getOrElse("") / `type`.getOrElse("") / "_mget").setBody(query.getBytes(StandardCharsets.UTF_8))
-    doRequest(req.POST)
+
+    val paramNames = List("_source")
+    val params = List(Option(uriParameters.sourceFields.map(_.trim).filter(_.nonEmpty).mkString(",")).filter(_.nonEmpty))
+    val freq = addQueryParams(req, paramNames, params)
+
+    doRequest(freq.POST)
   }
 
   /**
@@ -511,6 +518,12 @@ case class SearchUriParameters(searchType: Option[SearchType] = None,
                                scroll: Option[String] = None)
 object SearchUriParameters {
   val withDefaults = SearchUriParameters(None, None)
+}
+
+case class MGetUriParameters(sourceFields: Seq[String] = Nil)
+
+object MGetUriParameters {
+  val withDefaults = MGetUriParameters(Nil)
 }
 
 object Client {

--- a/src/main/scala/wabisabi/Client.scala
+++ b/src/main/scala/wabisabi/Client.scala
@@ -520,7 +520,7 @@ object SearchUriParameters {
   val withDefaults = SearchUriParameters(None, None)
 }
 
-case class MGetUriParameters(sourceFields: Seq[String] = Nil)
+case class MGetUriParameters(sourceFields: Seq[String] = Seq.empty)
 
 object MGetUriParameters {
   val withDefaults = MGetUriParameters(Nil)


### PR DESCRIPTION
There are two ways to retrieve only parts of the ```_source``` fields using ```mget``` API of elastic search : 
- using ```_source``` in request body like ```{ "docs" : { "_id" : 1, "_source" : [ "field1", "field2" ] }}```
- using ```_source``` as uri parameter like ``` localhost:9200/_mget?_source=field1,field2 ```

So far, the ```wabisabi``` can only support the first one. This pull request is to support the second one.
We encounter a problem when getting hundreds of document results using ```_mget``` with ```ids```. And if using the first way, the request body is too big to send all the ids. So we pull this request : )

Feel free to let us know if there is any problem. Thank you very much.