### PR TITLE
Make request lazy build when debugging

### DIFF
--- a/src/main/scala/wabisabi/Client.scala
+++ b/src/main/scala/wabisabi/Client.scala
@@ -469,7 +469,7 @@ class Client(esURL: String) extends Logging {
    * @param req The request
    */
   private def doRequest(req: Req) = {
-    val breq = req.toRequest
+    lazy val breq = req.toRequest
     debug("%s: %s".format(breq.getMethod, breq.getUrl))
     Http(req.setHeader("Content-type", "application/json; charset=utf-8"))
   }


### PR DESCRIPTION
The PR should be able to prevent building the request one more time but without usage when the `isDebugEnabled === false`. 