### PR TITLE
Remove the ignore_conflicts option from the put mappings API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: scala
-scala:
-  - 2.10.4
-  - 2.11.7
-jdk:
-  - oraclejdk7
-  - oraclejdk8
-sbt_args: -no-colors
+matrix:
+  include:
+    - scala: 2.11.7
+      jdk: oraclejdk7
+    - scala: 2.11.7
+      jdk: oraclejdk8
+    - scala: 2.12.1
+      jdk: oraclejdk8
+before_script:
+  - sudo chmod +x /usr/local/bin/sbt
+script:
+  - sbt -no-colors ++$TRAVIS_SCALA_VERSION test

--- a/README.md
+++ b/README.md
@@ -70,10 +70,9 @@ client.verifyIndex("foo").map(_.getStatusCode) // Should be Future(200)
 // Get mapping
 client.getMapping(indices = Seq("foo"), types = Seq("bar"))
 
-// Put mapping, optionally ignore conflicts
+// Put mapping
 client.putMapping(indices = Seq("foo"), `type` = "bar",
-  body = "{\"bar\": {\"properties\": {\"baz\": {\"type\": \"string\"}}}}",
-  ignoreConflicts = true
+  body = "{\"bar\": {\"properties\": {\"baz\": {\"type\": \"string\"}}}}"
 )
 
 // Add a document to the index.

--- a/src/main/scala/wabisabi/Client.scala
+++ b/src/main/scala/wabisabi/Client.scala
@@ -323,11 +323,9 @@ class Client(esURL: String, timeout: Int = 60000, _headers:Map[String, String] =
    * @param indices A sequence of index names for which mappings will be added.
    * @param type The type name to which the mappings will be applied.
    * @param body The mapping.
-   * @param ignoreConflicts When merge has conflicts overwrite mapping anyway, default false.
    */
-  def putMapping(indices: Seq[String], `type`: String, body: String, ignoreConflicts: Boolean = false): Future[Response] = {
+  def putMapping(indices: Seq[String], `type`: String, body: String): Future[Response] = {
     val req = (url(esURL) / indices.mkString(",") / `type` / "_mapping")
-      .setQueryParameters(Map("ignore_conflicts" -> List(ignoreConflicts.toString)))
       .setBody(body.getBytes(StandardCharsets.UTF_8))
     doRequest(req.PUT)
   }

--- a/src/test/scala/ClientSpec.scala
+++ b/src/test/scala/ClientSpec.scala
@@ -366,14 +366,6 @@ class ClientSpec extends Specification with JsonMatchers {
 
       Await.result(client.getMapping(Seq("foo"), Seq("foo")), testDuration).getResponseBody must contain("store")
 
-      Await.result(client.putMapping(Seq("foo"), "foo",
-        """{"foo": { "properties": { "message": { "type": "integer", "store": true } } } }""",
-        ignoreConflicts = false), testDuration).getResponseBody must contain("MergeMappingException")
-
-      Await.result(client.putMapping(Seq("foo"), "foo",
-        """{"foo": { "properties": { "message": { "type": "integer", "store": true } } } }""",
-        ignoreConflicts = true), testDuration).getResponseBody must contain("acknowledged")
-
       deleteIndex(client)("foo")
     }
 


### PR DESCRIPTION
Since ES 2.4, the `ignore_conflicts` option of the put mappings API is
no longer supported according to
https://www.elastic.co/guide/en/elasticsearch/reference/2.4/breaking_20_mapping_changes.html
It will cause an `illegal_argument_exception` error with 400 HTTP code
if the client is used on the ES with the later version.

This PR is to remove the `ignore_conflicts` option.

Related to the issue https://github.com/gphat/wabisabi/issues/51

PS. Fix the build.
